### PR TITLE
Update CMakeLists.txt.in

### DIFF
--- a/code/libs/googletest/CMakeLists.txt.in
+++ b/code/libs/googletest/CMakeLists.txt.in
@@ -4,7 +4,7 @@ project(googletest-download NONE)
 include(ExternalProject)
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
-  GIT_TAG           master
+  GIT_TAG           main
   SOURCE_DIR        "../src"
   BINARY_DIR        "../build"
   CONFIGURE_COMMAND ""


### PR DESCRIPTION
building with DBUILD_TESTS=ON resulted in the following error: fatal: invalid reference: master
CMake Error at download/googletest-prefix/tmp/googletest-gitclone.cmake:40 (message):
  Failed to checkout tag: 'master'